### PR TITLE
fixes a rails 6 bug.

### DIFF
--- a/lib/odbc_adapter/adapters/null_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/null_odbc_adapter.rb
@@ -4,10 +4,6 @@ module ODBCAdapter
     # registry. This allows for minimal support for DBMSs for which we don't
     # have an explicit adapter.
     class NullODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
-      class BindSubstitution < Arel::Visitors::ToSql
-        include Arel::Visitors::BindVisitor
-      end
-
       # Using a BindVisitor so that the SQL string gets substituted before it is
       # sent to the DBMS (to attempt to get as much coverage as possible for
       # DBMSs we don't support).


### PR DESCRIPTION
Arel::Bind::Visitor hasn't existed for a while, this fixes catalog-store odbc access to snowflake in CustomersBackend.